### PR TITLE
Recursove town search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 🇨🇿 Full documentation (czech) on [this site](https://async-bakalari-api.schizza.cz)
 
-[0.3.1]
+[unreleased]
+
+### Added
+
+- class `Schools()` is access by `Bakalari` class in `self.schools`
+
+### Changed
+
+- recursive search in towns when fetching `schools_list` from server
+
+## [0.3.1]
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
-dependencies-dev = { file = ["requirements-dev.txt"] }
 
 [tool.setuptools]
 platforms = ["any"]


### PR DESCRIPTION
Town search now supports recursive search for towns in the town list. 

* This is useful for example when you have a town with the same name in multiple regions or if for example you want to search `Ostrava` as a town and as a part of town `Moravska Ostrava`. 
* You can now use the `recursive` parameter in the `get_town` method. Default is enabled.