### PR TITLE
Fixes Bakalari credentials sharing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 🇨🇿 Full documentation (czech) on [this site](https://async-bakalari-api.schizza.cz)
 
-## [0.3.7]
+## [0.3.8]
+
+### Fixed
+ - `Credentials` in `Bakalari` is instance, not reference to credentials. This fixes issue with multiple instances of `Bakalari` sharing the same credentials.
+ 
+ ## [0.3.7]
 
 ### Fixed
  - `await` keyword was missing in the code snippet
@@ -123,6 +128,7 @@ All notable changes to this project will be documented in this file.
   - cache list of schools by saving and loading list in JSON format
 
 [unreleased]: https://github.com/schizza/bakalari-api3/compare/v0.0.1...HEAD
+[0.3.8]: https://github.com/schizza/bakalari-api3/releases/tag/0.3.8
 [0.3.7]: https://github.com/schizza/bakalari-api3/releases/tag/0.3.7
 [0.3.3]: https://github.com/schizza/bakalari-api3/releases/tag/0.3.3
 [0.3.2]: https://github.com/schizza/bakalari-api3/releases/tag/0.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "async_bakalari_api"
-version = "0.3.7"
+version = "0.3.8"
 dynamic = ["dependencies"]
 
 requires-python = ">=3.12"

--- a/src/async_bakalari_api/bakalari.py
+++ b/src/async_bakalari_api/bakalari.py
@@ -31,6 +31,7 @@ class Bakalari:
     def __init__(
         self,
         server: str | None = None,
+        credentials: Credentials | None = None,
         auto_cache_credentials: bool = False,
         cache_filename: str | None = None,
     ):
@@ -46,7 +47,7 @@ class Bakalari:
         """
 
         self.server = server
-        self.credentials = Credentials
+        self.credentials = Credentials()
         self.new_token = False
         self.auto_cache_credentials = auto_cache_credentials
         self.cache_filename = cache_filename
@@ -427,13 +428,13 @@ class Bakalari:
         try:
             with open(filename, "rb") as file:
                 data = orjson.loads(file.read())
+                self.credentials = Credentials.create_from_json(data)
+                return self.credentials
+
         except (OSError, orjson.JSONDecodeError):
             log.error(f"Error while loading credentials from file {filename}")
+            self.credentials = Credentials()
             return False
-
-        self.credentials = Credentials.create_from_json(data)
-
-        return self.credentials
 
     async def __aenter__(self) -> Self:
         """Async enter.


### PR DESCRIPTION
Ensures each Bakalari instance has its own Credentials object, resolving an issue where multiple instances shared the same credentials.

Updates pyproject.toml and CHANGELOG.md for version 0.3.8.